### PR TITLE
Added Solaris 11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This module has been tested to work on the following systems with Puppet v3 and 
  * EL 5
  * EL 6
  * Solaris 10
+ * Solaris 11
  * Suse 10
  * Suse 11
  * Ubuntu 12.04 LTS
@@ -42,6 +43,12 @@ Boolean to use hiera_hash which merges all found instances of nfs::mounts in Hie
 nfs_package
 -----------
 Name of the NFS package
+
+- *Default*: Uses system defaults as specified in module
+
+nfs_package_provider
+-----------
+Name of the NFS package provider
 
 - *Default*: Uses system defaults as specified in module
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,10 +3,11 @@
 # Manages NFS
 #
 class nfs (
-  $hiera_hash  = false,
-  $nfs_package = 'USE_DEFAULTS',
-  $nfs_service = 'USE_DEFAULTS',
-  $mounts      = undef,
+  $hiera_hash           = false,
+  $nfs_package          = 'USE_DEFAULTS',
+  $nfs_service          = 'USE_DEFAULTS',
+  $mounts               = undef,
+  $nfs_package_provider = 'USE_DEFAULTS',
 ) {
 
   if type($hiera_hash) == 'string' {
@@ -64,6 +65,13 @@ class nfs (
                               'SUNWnfssu']
 
       $default_nfs_service = 'nfs/client'
+
+      Package {
+        provider         => $nfs_package_provider ? {
+          'USE_DEFAULTS' => 'sun',
+          default        => $nfs_package_provider,
+        }
+      }
     }
     'Suse' : {
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -96,6 +96,16 @@ describe 'nfs' do
         :include_rpcbind => false,
         :packages        => ['SUNWnfsckr','SUNWnfscr','SUNWnfscu','SUNWnfsskr','SUNWnfssr','SUNWnfssu'],
         :service         => 'nfs/client',
+        :provider        => 'sun',
+      },
+    'solaris11' =>
+      { :osfamily        => 'Solaris',
+        :release         => '11',
+        :include_idmap   => false,
+        :include_rpcbind => false,
+        :packages        => ['SUNWnfsckr','SUNWnfscr','SUNWnfscu','SUNWnfsskr','SUNWnfssr','SUNWnfssu'],
+        :service         => 'nfs/client',
+        :provider        => 'sun',
       },
     'suse10' =>
       { :osfamily        => 'Suse',
@@ -149,6 +159,15 @@ describe 'nfs' do
                 'ensure' => 'present',
               })
             }
+
+          if v[:provider]
+            it {
+              should contain_package(pkg).with({
+                'provider' => v[:provider],
+              })
+            }
+          end
+
             # Building the array of Packages for service's subscribe attribute.
             service_subscribe << "Package[#{pkg}]"
           end


### PR DESCRIPTION
Added Solaris 11 support,
On older Solaris, 'sun' was always the default init provider, 
but on a newly installed Solaris 11, 'sun' seems not to be the default provider - and package check fails. 

Not sure if this implementation is in the best way.
