### PR TITLE
Fix nfs-idmap service startup issue in Redhat/EL 7.1, adjust package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This module has been tested to work on the following systems with Puppet v3
  * EL 7
  * Solaris 10
  * Solaris 11
+ * OmniOS r151016
  * Suse 10
  * Suse 11
  * Ubuntu 12.04 LTS
@@ -52,6 +53,12 @@ Name of the NFS package
 nfs_service
 -----------
 Name of the NFS service
+
+- *Default*: Uses system defaults as specified in module
+
+nfs_service_required_svcs
+-----------
+Array of services to enable prior to enabling NFS service.
 
 - *Default*: Uses system defaults as specified in module
 

--- a/manifests/idmap.pp
+++ b/manifests/idmap.pp
@@ -88,11 +88,12 @@ class nfs::idmap (
         '5','6': {
           $default_idmap_service = 'rpcidmapd'
           $default_idmap_package = 'nfs-utils-lib'
+          $idmapd_service_enable_temp = $idmapd_service_enable
         }
         '7': {
           $default_idmap_service = 'nfs-idmap'
           $default_idmap_package = 'libnfsidmap'
-          $idmapd_service_enable = false
+          $idmapd_service_enable_temp = false
         }
         default: {
           fail("idmap only supports EL versions 5, 6 and 7. Detected operatingsystemmajrelease is ${::operatingsystemmajrelease}.")
@@ -149,7 +150,7 @@ class nfs::idmap (
     service { 'idmapd_service':
       ensure     => running,
       name       => $idmapd_service_name_real,
-      enable     => $idmapd_service_enable,
+      enable     => $idmapd_service_enable_temp,
       hasstatus  => $idmapd_service_hasstatus,
       hasrestart => $idmapd_service_hasrestart,
       subscribe  => File['idmapd_conf'],

--- a/manifests/idmap.pp
+++ b/manifests/idmap.pp
@@ -160,7 +160,7 @@ class nfs::idmap (
       enable     => $idmapd_service_enable_real,
       hasstatus  => $idmapd_service_hasstatus,
       hasrestart => $idmapd_service_hasrestart,
-      require => Package[$idmap_package_real],
+      require    => Package[$idmap_package_real],
       subscribe  => File['idmapd_conf']
     }
   }

--- a/manifests/idmap.pp
+++ b/manifests/idmap.pp
@@ -160,7 +160,7 @@ class nfs::idmap (
       enable     => $idmapd_service_enable_real,
       hasstatus  => $idmapd_service_hasstatus,
       hasrestart => $idmapd_service_hasrestart,
-      require    => Package[$idmap_package_real],
+      require => Package[$idmap_package_real],
       subscribe  => File['idmapd_conf']
     }
   }

--- a/manifests/idmap.pp
+++ b/manifests/idmap.pp
@@ -160,6 +160,7 @@ class nfs::idmap (
       enable     => $idmapd_service_enable_real,
       hasstatus  => $idmapd_service_hasstatus,
       hasrestart => $idmapd_service_hasrestart,
+      require => Package[$idmap_package_real],
       subscribe  => File['idmapd_conf']
     }
   }

--- a/manifests/idmap.pp
+++ b/manifests/idmap.pp
@@ -92,6 +92,7 @@ class nfs::idmap (
         '7': {
           $default_idmap_service = 'nfs-idmap'
           $default_idmap_package = 'libnfsidmap'
+          $idmapd_service_enable = false
         }
         default: {
           fail("idmap only supports EL versions 5, 6 and 7. Detected operatingsystemmajrelease is ${::operatingsystemmajrelease}.")

--- a/manifests/idmap.pp
+++ b/manifests/idmap.pp
@@ -160,7 +160,6 @@ class nfs::idmap (
       enable     => $idmapd_service_enable_real,
       hasstatus  => $idmapd_service_hasstatus,
       hasrestart => $idmapd_service_hasrestart,
-      require => Package[$idmap_package_real],
       subscribe  => File['idmapd_conf']
     }
   }

--- a/manifests/idmap.pp
+++ b/manifests/idmap.pp
@@ -131,7 +131,6 @@ class nfs::idmap (
 
   package { $idmap_package_real:
     ensure => present,
-    require => { defined($nfs::nfs_package_real) ? Package[$nfs::nfs_package_real] : undef }
   }
 
   file { 'idmapd_conf':
@@ -148,7 +147,7 @@ class nfs::idmap (
 
     # On Redhat/EL 7.1+, the command 'systemctl enable nfs-idmap' fails per
     # https://bugzilla.redhat.com/show_bug.cgi?id=1159308
-    if versioncmp($::operatingsystemrelease, '7.0') > 0  && versioncmp($::operatingsystemrelease, '8.0') < 0 {
+    if versioncmp($::operatingsystemrelease, '7.0') > 0 and versioncmp($::operatingsystemrelease, '8.0') < 0 {
       $idmapd_service_enable_real = false
     }
     else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,7 @@ class nfs (
           fail("nfs module only supports lsbdistid Debian and Ubuntu of osfamily Debian. Detected lsbdistid is <${::lsbdistid}>.")
         }
       }
+      $default_nfs_service_required_svcs = undef
     }
     'RedHat': {
 
@@ -58,28 +59,33 @@ class nfs (
           fail("nfs module only supports EL 5, 6 and 7 and operatingsystemmajrelease was detected as <${::operatingsystemmajrelease}>.")
         }
       }
+      $default_nfs_service_required_svcs = undef
     }
     'Solaris': {
       case $::kernelrelease {
         '5.10': {
           $default_nfs_package = [ 'SUNWnfsckr',
-                                    'SUNWnfscr',
-                                    'SUNWnfscu',
-                                    'SUNWnfsskr',
-                                    'SUNWnfssr',
-                                    'SUNWnfssu',
+                                   'SUNWnfscr',
+                                   'SUNWnfscu',
+                                   'SUNWnfsskr',
+                                   'SUNWnfssr',
+                                   'SUNWnfssu',
           ]
+          $default_nfs_service_required_svcs = undef
         }
         '5.11': {
           $default_nfs_package = [ 'service/file-system/nfs',
-                                    'system/file-system/nfs',
+                                   'system/file-system/nfs',
+          ]
+
+          $default_nfs_service_required_svcs = [ 'nfs/status',
+                                                 'nfs/nlockmgr',
           ]
         }
         default: {
           fail("nfs module only supports Solaris 5.10 and 5.11 and kernelrelease was detected as <${::kernelrelease}>.")
         }
       }
-
       $default_nfs_service = 'nfs/client'
     }
     'Suse' : {
@@ -100,6 +106,7 @@ class nfs (
           fail("nfs module only supports Suse 10 and 11 and lsbmajdistrelease was detected as <${::lsbmajdistrelease}>.")
         }
       }
+      $default_nfs_service_required_svcs = undef
     }
 
     default: {
@@ -115,8 +122,10 @@ class nfs (
 
   if $nfs_service == 'USE_DEFAULTS' {
     $nfs_service_real = $default_nfs_service
+    $nfs_service_required_svcs_real = $default_nfs_service_required_svcs
   } else {
     $nfs_service_real = $nfs_service
+    $nfs_service_required_svcs_real = undef
   }
 
   $nfs_package_before = $::osfamily ? {
@@ -128,6 +137,14 @@ class nfs (
     before => $nfs_package_before,
   }
 
+  if $nfs_service_required_svcs_real and $nfs_service_real {
+   service { $nfs_service_required_svcs_real:
+      ensure    => running,
+      enable    => true,
+      subscribe => Package[$nfs_package_real],
+      before    => Service['nfs_service'],
+   }
+  }
   if $nfs_service_real {
     service { 'nfs_service':
       ensure    => running,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,12 +119,13 @@ class nfs (
     $nfs_service_real = $nfs_service
   }
 
+  $nfs_package_before = $::osfamily ? {
+      'RedHat' => Class['Nfs::Idmap'],
+      default  => undef,
+  }
   package { $nfs_package_real:
     ensure => present,
-    before => $::osfamily ? {
-      'RedHat' => Class['Nfs::Idmap'],
-      default => undef,
-    }
+    before => $nfs_package_before,
   }
 
   if $nfs_service_real {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,10 +3,11 @@
 # Manages NFS
 #
 class nfs (
-  $hiera_hash  = false,
-  $nfs_package = 'USE_DEFAULTS',
-  $nfs_service = 'USE_DEFAULTS',
-  $mounts      = undef,
+  $hiera_hash                = false,
+  $nfs_package               = 'USE_DEFAULTS',
+  $nfs_service               = 'USE_DEFAULTS',
+  $nfs_service_required_svcs = 'USE_DEFAULTS',
+  $mounts                    = undef,
 ) {
 
   if type3x($hiera_hash) == 'string' {
@@ -64,22 +65,25 @@ class nfs (
     'Solaris': {
       case $::kernelrelease {
         '5.10': {
-          $default_nfs_package = [ 'SUNWnfsckr',
-                                   'SUNWnfscr',
-                                   'SUNWnfscu',
-                                   'SUNWnfsskr',
-                                   'SUNWnfssr',
-                                   'SUNWnfssu',
+          $default_nfs_package = [
+            'SUNWnfsckr',
+            'SUNWnfscr',
+            'SUNWnfscu',
+            'SUNWnfsskr',
+            'SUNWnfssr',
+            'SUNWnfssu',
           ]
           $default_nfs_service_required_svcs = undef
         }
         '5.11': {
-          $default_nfs_package = [ 'service/file-system/nfs',
-                                   'system/file-system/nfs',
+          $default_nfs_package = [
+            'service/file-system/nfs',
+            'system/file-system/nfs',
           ]
 
-          $default_nfs_service_required_svcs = [ 'nfs/status',
-                                                 'nfs/nlockmgr',
+          $default_nfs_service_required_svcs = [
+            'nfs/status',
+            'nfs/nlockmgr',
           ]
         }
         default: {
@@ -122,10 +126,14 @@ class nfs (
 
   if $nfs_service == 'USE_DEFAULTS' {
     $nfs_service_real = $default_nfs_service
-    $nfs_service_required_svcs_real = $default_nfs_service_required_svcs
   } else {
     $nfs_service_real = $nfs_service
-    $nfs_service_required_svcs_real = undef
+  }
+
+  if $nfs_service_required_svcs == 'USE_DEFAULTS' {
+    $nfs_service_required_svcs_real = $default_nfs_service_required_svcs
+  } else {
+    $nfs_service_required_svcs_real = $nfs_service_required_svcs
   }
 
   $nfs_package_before = $::osfamily ? {
@@ -137,7 +145,7 @@ class nfs (
     before => $nfs_package_before,
   }
 
-  if $nfs_service_required_svcs_real and $nfs_service_real {
+  if $nfs_service_required_svcs_real != undef and $nfs_service_real != undef {
    service { $nfs_service_required_svcs_real:
       ensure    => running,
       enable    => true,
@@ -145,7 +153,7 @@ class nfs (
       before    => Service['nfs_service'],
    }
   }
-  if $nfs_service_real {
+  if $nfs_service_real != undef {
     service { 'nfs_service':
       ensure    => running,
       name      => $nfs_service_real,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,6 +121,7 @@ class nfs (
 
   package { $nfs_package_real:
     ensure => present,
+    before => Class['Nfs::Idmap']
   }
 
   if $nfs_service_real {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -146,12 +146,12 @@ class nfs (
   }
 
   if $nfs_service_required_svcs_real != undef and $nfs_service_real != undef {
-   service { $nfs_service_required_svcs_real:
+    service { $nfs_service_required_svcs_real:
       ensure    => running,
       enable    => true,
       subscribe => Package[$nfs_package_real],
       before    => Service['nfs_service'],
-   }
+    }
   }
   if $nfs_service_real != undef {
     service { 'nfs_service':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,7 @@ class nfs (
   package { $nfs_package_real:
     ensure => present,
     before => $::osfamily ? {
-      'Redhat' => Class['Nfs::Idmap'],
+      'RedHat' => Class['Nfs::Idmap'],
       default => undef,
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,7 +121,10 @@ class nfs (
 
   package { $nfs_package_real:
     ensure => present,
-    before => Class['Nfs::Idmap']
+    before => $::osfamily ? {
+      'Redhat' => Class['Nfs::Idmap'],
+      default => undef,
+    }
   }
 
   if $nfs_service_real {


### PR DESCRIPTION
This PR seeks to address the following issues observed under Redhat/EL 7.1:
1. Attempting to start the nfs-idmap service before "nfs-utils" package is installed fails.  Adding package install ordering to avoid this.
2. Due to systemd changes in Redhat/EL 7.1+, the command "systemctl enable nfs-idmap" fails.  So, the idmap.pp manifest now just doesn't run that command for v7.1.

The systemd command is reported to work fine under 7.0.  Apparently, it's disputed whether this is a regression.  More info:  https://bugzilla.redhat.com/show_bug.cgi?id=1159308
