### PR TITLE
Revised support for Solaris/OmniOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This module has been tested to work on the following systems with Puppet v3
  * EL 7
  * Solaris 10
  * Solaris 11
+ * OmniOS r151016
  * Suse 10
  * Suse 11
  * Suse 12
@@ -53,6 +54,12 @@ Name of the NFS package
 nfs_service
 -----------
 Name of the NFS service
+
+- *Default*: Uses system defaults as specified in module
+
+nfs_service_required_svcs
+-----------
+Array of services to enable prior to enabling NFS service.
 
 - *Default*: Uses system defaults as specified in module
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -141,12 +141,12 @@ class nfs (
   }
 
   if $nfs_service_required_svcs_real != undef and $nfs_service_real != undef {
-   service { $nfs_service_required_svcs_real:
+    service { $nfs_service_required_svcs_real:
       ensure    => running,
       enable    => true,
       subscribe => Package[$nfs_package_real],
       before    => Service['nfs_service'],
-   }
+    }
   }
   if $nfs_service_real != undef {
     service { 'nfs_service':


### PR DESCRIPTION
This PR includes ordering for enabling the following services (in this order):
- nfs/status
- nfs/nlockmgr
- nfs/client

Starting these services in any other order causes nfs/nlockmgr or nfs/client to fail startup on missing dependencies.  Tested on OmniOS r151014 under vagrant.